### PR TITLE
Track push failure counts in notify stats

### DIFF
--- a/backend/src/__tests__/system.stats.test.ts
+++ b/backend/src/__tests__/system.stats.test.ts
@@ -35,5 +35,19 @@ describe('/api/stats env fields', () => {
     expect(res.body.data.env.specVersion).toBe('9.9.9');
     expect(res.body.data.env.buildSha).toBe('deadbeef');
   });
+
+  it('reports push success rate using delivered and failed counters', async () => {
+    const { resetNotifyCounters, incrPushSuccess, incrPushFail } = require('../utils/notifyStats');
+    resetNotifyCounters();
+    incrPushSuccess(7);
+    incrPushFail(undefined, 3);
+    const app = require('../app').default;
+    const res = await request(app).get('/api/stats');
+
+    expect(res.status).toBe(200);
+    const pushRate = res.body?.data?.notifications?.successRate?.push;
+    expect(pushRate).not.toBeNull();
+    expect(pushRate).toBeCloseTo(7 / (7 + 3));
+  });
 });
 

--- a/backend/src/services/pushService.ts
+++ b/backend/src/services/pushService.ts
@@ -148,8 +148,10 @@ export async function sendPushToUsers(
         logger.warn('PUSH: %d ungültige Tokens deaktiviert', toDisable.length);
       }
     }
-    incrPushSuccess(tokens.length - (resp.failureCount || 0));
-    if ((resp.failureCount || 0) > 0) incrPushFail();
+    const failureCount = Math.max(0, resp.failureCount ?? 0);
+    const deliveredCount = Math.max(0, tokens.length - failureCount);
+    incrPushSuccess(deliveredCount);
+    if (failureCount > 0) incrPushFail(undefined, failureCount);
     queueJobSucceeded(queueName);
     publishNotificationEvent({
       channel: 'push',
@@ -159,8 +161,8 @@ export async function sendPushToUsers(
       title,
       body,
       metadata: {
-        delivered: tokens.length - (resp.failureCount || 0),
-        failed: resp.failureCount || 0,
+        delivered: deliveredCount,
+        failed: failureCount,
         reason: options.reason || 'custom',
         ...((options.context && Object.keys(options.context).length) ? { context: options.context } : {}),
       },

--- a/backend/src/utils/notifyStats.ts
+++ b/backend/src/utils/notifyStats.ts
@@ -17,9 +17,15 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-function recordAttempt(group: CounterGroup): string {
+function normalizeIncrement(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  return Math.floor(value);
+}
+
+function recordAttempt(group: CounterGroup, increment = 1): string {
   const ts = nowIso();
-  group.attempts += 1;
+  group.attempts += normalizeIncrement(increment);
   group.lastAttemptAt = ts;
   return ts;
 }
@@ -31,9 +37,9 @@ function recordSuccess(group: CounterGroup, increment = 1): void {
   group.lastError = undefined;
 }
 
-function recordFailure(group: CounterGroup, error?: unknown): void {
-  const ts = recordAttempt(group);
-  group.fail += 1;
+function recordFailure(group: CounterGroup, error?: unknown, increment = 1): void {
+  const ts = recordAttempt(group, increment);
+  group.fail += normalizeIncrement(increment);
   group.lastFailAt = ts;
   if (error) {
     group.lastError = error instanceof Error ? error.message : String(error);
@@ -52,8 +58,8 @@ export function incrPushSuccess(delivered: number): void {
   recordSuccess(counters.push, delivered);
 }
 
-export function incrPushFail(error?: unknown): void {
-  recordFailure(counters.push, error);
+export function incrPushFail(error?: unknown, count = 1): void {
+  recordFailure(counters.push, error, count);
 }
 
 export function getNotifyCounters() {


### PR DESCRIPTION
## Summary
- update notify stats helpers so push failures increment by the number of affected tokens
- propagate multicast failure counts through the push service and emitted notification metadata
- extend push service and system stats tests to cover partial failures and success-rate reporting

## Testing
- not run (tests not configured)

------
https://chatgpt.com/codex/tasks/task_e_68cac35e3f488329ae44b6141e76f747