### PR TITLE
feat: expand audit instrumentation and observability

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -32,7 +32,7 @@ Du bist Senior-Full-Stack-Entwickler (Node.js, TypeScript, Express, Prisma, Post
 ## Roadmap (Priorität – kurz)
 1) ✅ **Observability** – `/api/stats` um Laufzeit-/Queue-/Success-Rate erweitert & README Logging-Runbook (2025-09-15).
 2) ✅ **Notifications** – Templates, Echtzeit-Events & Opt-In/Out vorbereitet (Feature-Flags, Tests, Docs) (2025-09-16).
-3) ✅ **Security-Hardening** – Phase E (Retention-Job `npm run audit:prune`, Prometheus-Metriken, `/api/stats` Audit-Kennzahlen) abgeschlossen 2025-09-19; Phase D (Audit-CSV-Export) 2025-09-19; Phase C (Audit-Events + Read-API) 2025-09-19; Phase B (Prisma-AuditLog + Queue) 2025-09-18; Phase A (Blueprint & Limits) 2025-09-17. Nächste Schritte: Dashboards & Alerting feintunen.
+3) ✅ **Security-Hardening** – Phase E (Retention-Job `npm run audit:prune`, Prometheus-Metriken, `/api/stats` Audit-Kennzahlen) abgeschlossen 2025-09-19; Phase D (Audit-CSV-Export) 2025-09-19; Phase C (Audit-Events + Read-API) 2025-09-19; Phase B (Prisma-AuditLog + Queue) 2025-09-18; Phase A (Blueprint & Limits) 2025-09-17. Audit-Helfer (`buildAuditEvent`/`submitAuditEvent`) decken Auth/Users/Shifts/Incidents/Notifications ab, `/api/stats.audit` zeigt Queue-State. Nächste Schritte: Dashboards & Alerting feintunen.
 4) ⏭️ **Telemetry/Dashboards** – Prometheus/Grafana Panels versionieren, PromQL-Snippets dokumentieren.
 5) ⏭️ **Ops/Compose** – Healthchecks & Migrationslauf in Docker-Stacks finalisieren (`docker-compose*.yml`, `.env.example`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- security: Konsistenter Audit-Helfer (`buildAuditEvent`/`submitAuditEvent`) für Auth-, User-, Shift-, Incident- und Notification-Controller inkl. Fehlerpfade (Login/Refresh, verbotene Self-Updates, Incident CRUD, Test-Benachrichtigungen).
 - docs: Security-Hardening Blueprint (`docs/planning/security-hardening.md`) mit Rate-Limit- und Audit-Trail-Konzept.
 - backend/shifts: Selektive Rate-Limits für Schicht-Zuweisung (`SHIFT_ASSIGN_RATE_LIMIT_*`) sowie Clock-in/out (`SHIFT_CLOCK_RATE_LIMIT_*`) inkl. Tests & ENV-Beispielen.
 - security: Prisma `AuditLog` Modell + Migration, Logging-Service (`logAuditEvent`/`flushAuditLogQueue`) mit Retry-Queue, Tests & Doku (Phase B).
@@ -26,6 +27,8 @@ All notable changes to this project will be documented in this file.
 - repo: commitlint (Conventional Commits) + PR‑Template Checkliste.
 
 ### Changed
+- security: Audit-Log-Service wirft bei fehlendem Prisma-Modell keine Fehler mehr, sondern verwirft Events mit Warnung und liefert Laufzeitstatus via `getAuditLogState`.
+- observability: `/api/stats` ergänzt ein separates `audit`-Objekt mit Queue-Größe, Flush-Flags und Intervallen; bestehende `auditTrail.queue`-Daten spiegeln denselben Zustand wider.
 - shifts: `/api/shifts/:id/assign` erfordert nun Rollen `ADMIN`/`DISPATCHER` und trägt Rate-Limit-Header für wiederholte Aufrufe.
 - notifications/test: Channel `push` unterstützt, Validierung via Zod (Template-Key, userIds, Variablen) erweitert; Versand tracked Event-Stream.
 - readiness: SMTP-Verify liefert Diagnose (`deps.smtpMessage`) und schließt Transport nach Erfolg/Fehlschlag.

--- a/backend/src/__tests__/system.stats.test.ts
+++ b/backend/src/__tests__/system.stats.test.ts
@@ -66,6 +66,16 @@ afterEach(() => {
     expect(payload.success).toBe(true);
     expect(payload.data.env.specVersion).toBe('9.9.9');
     expect(payload.data.env.buildSha).toBe('deadbeef');
+    expect(payload.data.audit).toEqual(
+      expect.objectContaining({
+        queueSize: expect.any(Number),
+        flushIntervalMs: expect.any(Number),
+        batchSize: expect.any(Number),
+        maxQueueSize: expect.any(Number),
+        isFlushing: expect.any(Boolean),
+        hasScheduledFlush: expect.any(Boolean),
+      }),
+    );
   });
 
   it('reports push success rate using delivered and failed counters', async () => {
@@ -109,5 +119,15 @@ afterEach(() => {
       outcomes: expect.objectContaining({ SUCCESS: 80, DENIED: 15, ERROR: 5 }),
       latest: expect.objectContaining({ id: 'log-latest' }),
     });
+    expect(payload?.data?.audit).toEqual(
+      expect.objectContaining({
+        queueSize: expect.any(Number),
+        flushIntervalMs: expect.any(Number),
+        batchSize: expect.any(Number),
+        maxQueueSize: expect.any(Number),
+        isFlushing: expect.any(Boolean),
+        hasScheduledFlush: expect.any(Boolean),
+      }),
+    );
   });
 });

--- a/backend/src/controllers/shiftController.ts
+++ b/backend/src/controllers/shiftController.ts
@@ -4,7 +4,7 @@ import ExcelJS from 'exceljs';
 import logger from '../utils/logger';
 import { sendShiftChangedEmail } from '../services/emailService';
 import { streamCsv } from '../utils/csv';
-import { recordAuditEvent } from '../utils/auditTrail';
+import { submitAuditEvent } from '../utils/audit';
 
 const EMAIL_FLAG = 'EMAIL_NOTIFY_SHIFTS';
 
@@ -290,7 +290,7 @@ export const createShift = async (req: Request, res: Response, next: NextFunctio
     } catch {
       // bereits intern geloggt
     }
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.CREATE',
       resourceType: 'SHIFT',
       resourceId: shift.id,
@@ -308,7 +308,7 @@ export const createShift = async (req: Request, res: Response, next: NextFunctio
     });
   } catch (error) {
     console.error('Error creating shift:', error);
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.CREATE',
       resourceType: 'SHIFT',
       outcome: 'ERROR',
@@ -430,7 +430,7 @@ export const updateShift = async (req: Request, res: Response, next: NextFunctio
     } catch {
       // bereits intern geloggt
     }
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.UPDATE',
       resourceType: 'SHIFT',
       resourceId: updatedShift.id,
@@ -449,7 +449,7 @@ export const updateShift = async (req: Request, res: Response, next: NextFunctio
     console.error('Error updating shift:', error);
 
     if (error.code === 'P2025') {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.UPDATE',
         resourceType: 'SHIFT',
         resourceId: req.params.id,
@@ -463,7 +463,7 @@ export const updateShift = async (req: Request, res: Response, next: NextFunctio
       return;
     }
 
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.UPDATE',
       resourceType: 'SHIFT',
       resourceId: req.params.id,
@@ -511,7 +511,7 @@ export const deleteShift = async (req: Request, res: Response, next: NextFunctio
     } catch {
       // bereits intern geloggt
     }
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.DELETE',
       resourceType: 'SHIFT',
       resourceId: deletedShift.id,
@@ -527,7 +527,7 @@ export const deleteShift = async (req: Request, res: Response, next: NextFunctio
     console.error('Error deleting shift:', error);
 
     if (error.code === 'P2025') {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.DELETE',
         resourceType: 'SHIFT',
         resourceId: req.params.id,
@@ -541,7 +541,7 @@ export const deleteShift = async (req: Request, res: Response, next: NextFunctio
       return;
     }
 
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.DELETE',
       resourceType: 'SHIFT',
       resourceId: req.params.id,
@@ -559,7 +559,7 @@ export const assignUserToShift = async (req: Request, res: Response, next: NextF
     const { userId } = req.body;
 
     if (!userId) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.ASSIGN',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -580,7 +580,7 @@ export const assignUserToShift = async (req: Request, res: Response, next: NextF
     });
 
     if (!shift) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.ASSIGN',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -605,7 +605,7 @@ export const assignUserToShift = async (req: Request, res: Response, next: NextF
     });
 
     if (existingAssignment) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.ASSIGN',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -646,7 +646,7 @@ export const assignUserToShift = async (req: Request, res: Response, next: NextF
       },
     });
 
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.ASSIGN',
       resourceType: 'SHIFT',
       resourceId: shiftId,
@@ -662,7 +662,7 @@ export const assignUserToShift = async (req: Request, res: Response, next: NextF
     console.error('Error assigning user to shift:', error);
 
     if (error.code === 'P2002') {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.ASSIGN',
         resourceType: 'SHIFT',
         resourceId: req.params.id,
@@ -676,7 +676,7 @@ export const assignUserToShift = async (req: Request, res: Response, next: NextF
       return;
     }
 
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.ASSIGN',
       resourceType: 'SHIFT',
       resourceId: req.params.id,
@@ -694,7 +694,7 @@ export const clockIn = async (req: Request, res: Response, next: NextFunction) =
     const userId = (req.user as any)?.id;
     const { at, location, notes } = req.body;
     if (!userId) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.CLOCK_IN',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -708,7 +708,7 @@ export const clockIn = async (req: Request, res: Response, next: NextFunction) =
       where: { userId_shiftId: { userId, shiftId } },
     });
     if (!assigned) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.CLOCK_IN',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -720,7 +720,7 @@ export const clockIn = async (req: Request, res: Response, next: NextFunction) =
     }
     const open = await prisma.timeEntry.findFirst({ where: { userId, endTime: null } });
     if (open) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.CLOCK_IN',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -743,7 +743,7 @@ export const clockIn = async (req: Request, res: Response, next: NextFunction) =
       const hoursRest = (start.getTime() - new Date(last.endTime).getTime()) / 3_600_000;
       if (hoursRest < 11) warnings.push('WARN_REST_PERIOD_LT_11H');
     }
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.CLOCK_IN',
       resourceType: 'SHIFT',
       resourceId: shiftId,
@@ -752,7 +752,7 @@ export const clockIn = async (req: Request, res: Response, next: NextFunction) =
     });
     res.json({ success: true, message: 'Clock-in erfasst', data: entry, warnings });
   } catch (error) {
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.CLOCK_IN',
       resourceType: 'SHIFT',
       resourceId: req.params.id,
@@ -770,7 +770,7 @@ export const clockOut = async (req: Request, res: Response, next: NextFunction) 
     const userId = (req.user as any)?.id;
     const { at, breakTime, location, notes } = req.body;
     if (!userId) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.CLOCK_OUT',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -784,7 +784,7 @@ export const clockOut = async (req: Request, res: Response, next: NextFunction) 
       where: { userId_shiftId: { userId, shiftId } },
     });
     if (!assigned) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.CLOCK_OUT',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -796,7 +796,7 @@ export const clockOut = async (req: Request, res: Response, next: NextFunction) 
     }
     const open = await prisma.timeEntry.findFirst({ where: { userId, endTime: null }, orderBy: { startTime: 'desc' } });
     if (!open) {
-      await recordAuditEvent(req, {
+      await submitAuditEvent(req, {
         action: 'SHIFT.CLOCK_OUT',
         resourceType: 'SHIFT',
         resourceId: shiftId,
@@ -821,7 +821,7 @@ export const clockOut = async (req: Request, res: Response, next: NextFunction) 
       (end.getTime() - new Date(updated.startTime).getTime()) / 3_600_000 - (updated.breakTime ? updated.breakTime / 60 : 0);
     if (durationHours > 12) warnings.push('WARN_SHIFT_GT_12H');
     if (durationHours > 10) warnings.push('WARN_SHIFT_GT_10H');
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.CLOCK_OUT',
       resourceType: 'SHIFT',
       resourceId: shiftId,
@@ -830,7 +830,7 @@ export const clockOut = async (req: Request, res: Response, next: NextFunction) 
     });
     res.json({ success: true, message: 'Clock-out erfasst', data: updated, warnings });
   } catch (error) {
-    await recordAuditEvent(req, {
+    await submitAuditEvent(req, {
       action: 'SHIFT.CLOCK_OUT',
       resourceType: 'SHIFT',
       resourceId: req.params.id,

--- a/backend/src/controllers/systemController.ts
+++ b/backend/src/controllers/systemController.ts
@@ -7,7 +7,7 @@ import { getNotifyCounters } from '../utils/notifyStats';
 import { getQueueSnapshot, type QueueState } from '../utils/queueStats';
 import { getRuntimeMetrics } from '../utils/runtimeMetrics';
 import { getNotificationStreamStats } from '../utils/notificationEvents';
-import { getAuditLogQueueSize } from '../services/auditLogService';
+import { getAuditLogState } from '../services/auditLogService';
 
 // Lightweight health endpoint (no deps)
 export const healthz = async (_req: Request, res: Response): Promise<void> => {
@@ -206,12 +206,7 @@ export const getSystemStats = async (req: Request, res: Response, next: NextFunc
       return acc;
     }, {});
 
-    const auditQueueConfig = {
-      flushIntervalMs: Number(process.env.AUDIT_LOG_FLUSH_INTERVAL_MS || 2000),
-      batchSize: Number(process.env.AUDIT_LOG_BATCH_SIZE || 25),
-      maxQueueSize: Number(process.env.AUDIT_LOG_MAX_QUEUE || 1000),
-      pending: getAuditLogQueueSize(),
-    };
+    const auditState = getAuditLogState();
 
     res.json({
       success: true,
@@ -271,8 +266,9 @@ export const getSystemStats = async (req: Request, res: Response, next: NextFunc
                 outcome: latestAuditEvent.outcome,
               }
             : null,
-          queue: auditQueueConfig,
+          queue: auditState,
         },
+        audit: auditState,
         env: {
           nodeEnv: process.env.NODE_ENV || 'development',
           version: process.env.npm_package_version || '1.0.0',

--- a/backend/src/utils/audit.ts
+++ b/backend/src/utils/audit.ts
@@ -1,0 +1,87 @@
+import type { Request } from 'express';
+import { logAuditEvent, type AuditLogEventInput } from '../services/auditLogService';
+import logger from './logger';
+
+export type RequestActor = { id?: string | null; role?: string | null } | undefined;
+
+type BuildableAuditEvent = Omit<AuditLogEventInput, 'actorId' | 'actorRole' | 'actorIp' | 'requestId' | 'userAgent'> &
+  Partial<Pick<AuditLogEventInput, 'actorId' | 'actorRole' | 'actorIp' | 'requestId' | 'userAgent'>>;
+
+function normalizeUserAgent(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function getRequestUser(req: Request): RequestActor {
+  return (req.user as RequestActor) || undefined;
+}
+
+export function extractClientIp(req: Request): string | null {
+  const headerCandidates: Array<string | string[] | undefined> = [
+    req.headers['x-forwarded-for'],
+    req.headers['x-real-ip'],
+    req.headers['cf-connecting-ip'],
+  ];
+
+  for (const header of headerCandidates) {
+    if (!header) {
+      continue;
+    }
+    if (Array.isArray(header)) {
+      const value = header.find((entry) => entry && entry.trim().length > 0);
+      if (value) {
+        return value.split(',')[0]?.trim() || null;
+      }
+      continue;
+    }
+    if (typeof header === 'string' && header.trim().length > 0) {
+      return header.split(',')[0]?.trim() || null;
+    }
+  }
+
+  if (typeof req.ip === 'string' && req.ip.length > 0) {
+    return req.ip;
+  }
+
+  const socketIp = req.socket?.remoteAddress;
+  return typeof socketIp === 'string' && socketIp.length > 0 ? socketIp : null;
+}
+
+function resolveRequestId(req: Request): string | null {
+  if (typeof (req as any).id === 'string' && (req as any).id.length > 0) {
+    return (req as any).id;
+  }
+  const headerId = req.headers['x-request-id'];
+  if (typeof headerId === 'string' && headerId.length > 0) {
+    return headerId;
+  }
+  return null;
+}
+
+export function buildAuditEvent(req: Request, event: BuildableAuditEvent): AuditLogEventInput {
+  const actor = getRequestUser(req);
+  return {
+    action: event.action,
+    resourceType: event.resourceType,
+    resourceId: event.resourceId ?? null,
+    actorId: event.actorId ?? actor?.id ?? null,
+    actorRole: event.actorRole ?? actor?.role ?? null,
+    actorIp: event.actorIp ?? extractClientIp(req),
+    requestId: event.requestId ?? resolveRequestId(req),
+    userAgent: event.userAgent ?? normalizeUserAgent(req.headers['user-agent']),
+    outcome: event.outcome ?? null,
+    data: event.data ?? null,
+    occurredAt: event.occurredAt ?? new Date(),
+  };
+}
+
+export async function submitAuditEvent(req: Request, event: BuildableAuditEvent): Promise<void> {
+  try {
+    await logAuditEvent(buildAuditEvent(req, event));
+  } catch (error) {
+    logger.warn('Failed to submit audit event: %o', error);
+  }
+}
+
+export function getAuditActorIp(req: Request): string | null {
+  return extractClientIp(req);
+}

--- a/backend/src/utils/auditTrail.ts
+++ b/backend/src/utils/auditTrail.ts
@@ -1,68 +1,29 @@
 import type { Request } from 'express';
-import logger from './logger';
-import { logAuditEvent, type AuditLogEventInput } from '../services/auditLogService';
+import { type AuditLogEventInput } from '../services/auditLogService';
+import { extractClientIp, submitAuditEvent } from './audit';
 
 export type AuditEventDetails = Pick<AuditLogEventInput, 'action' | 'resourceType' | 'resourceId' | 'outcome' | 'data' | 'occurredAt'>;
 
 export type AuditActorOverrides = Pick<AuditLogEventInput, 'actorId' | 'actorRole' | 'actorIp' | 'userAgent' | 'requestId'>;
-
-function extractClientIp(req: Request): string | null {
-  const headerCandidates: Array<string | string[] | undefined> = [
-    req.headers['x-forwarded-for'],
-    req.headers['x-real-ip'],
-    req.headers['cf-connecting-ip'],
-  ];
-
-  for (const header of headerCandidates) {
-    if (!header) {
-      continue;
-    }
-    if (Array.isArray(header)) {
-      const value = header.find((entry) => entry && entry.trim().length > 0);
-      if (value) {
-        return value.split(',')[0]?.trim() || null;
-      }
-      continue;
-    }
-    if (typeof header === 'string' && header.trim().length > 0) {
-      return header.split(',')[0]?.trim() || null;
-    }
-  }
-
-  if (typeof req.ip === 'string' && req.ip.length > 0) {
-    return req.ip;
-  }
-
-  const socketIp = req.socket?.remoteAddress;
-  return typeof socketIp === 'string' && socketIp.length > 0 ? socketIp : null;
-}
 
 export async function recordAuditEvent(
   req: Request,
   details: AuditEventDetails,
   overrides: AuditActorOverrides = {},
 ): Promise<void> {
-  const event: AuditLogEventInput = {
+  await submitAuditEvent(req, {
     action: details.action,
     resourceType: details.resourceType,
     resourceId: details.resourceId ?? null,
     outcome: details.outcome ?? null,
     data: details.data ?? null,
     occurredAt: details.occurredAt ?? new Date(),
-    actorId: overrides.actorId ?? req.user?.id ?? null,
-    actorRole: overrides.actorRole ?? req.user?.role ?? null,
-    actorIp: overrides.actorIp ?? extractClientIp(req),
-    requestId: overrides.requestId ?? req.id ?? (typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : null),
-    userAgent:
-      overrides.userAgent ??
-      (typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : null),
-  };
-
-  try {
-    await logAuditEvent(event);
-  } catch (error) {
-    logger.warn('Failed to record audit event: %o', error);
-  }
+    actorId: overrides.actorId,
+    actorRole: overrides.actorRole,
+    actorIp: overrides.actorIp,
+    userAgent: overrides.userAgent,
+    requestId: overrides.requestId,
+  });
 }
 
 export function getAuditActorIp(req: Request): string | null {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3903,11 +3903,22 @@ paths:
                         queue:
                           type: object
                           properties:
+                            queueSize: { type: integer }
                             flushIntervalMs: { type: integer }
                             batchSize: { type: integer }
                             maxQueueSize: { type: integer }
-                            pending: { type: integer }
+                            isFlushing: { type: boolean }
+                            hasScheduledFlush: { type: boolean }
                       required: [total, last24h, outcomes, queue]
+                    audit:
+                      type: object
+                      properties:
+                        queueSize: { type: integer }
+                        flushIntervalMs: { type: integer }
+                        batchSize: { type: integer }
+                        maxQueueSize: { type: integer }
+                        isFlushing: { type: boolean }
+                        hasScheduledFlush: { type: boolean }
                   queues:
                     type: object
                     additionalProperties:
@@ -4008,10 +4019,19 @@ paths:
                         action: SHIFT.ASSIGN
                         outcome: SUCCESS
                       queue:
+                        queueSize: 0
                         flushIntervalMs: 2000
                         batchSize: 25
                         maxQueueSize: 1000
-                        pending: 0
+                        isFlushing: false
+                        hasScheduledFlush: false
+                    audit:
+                      queueSize: 0
+                      flushIntervalMs: 2000
+                      batchSize: 25
+                      maxQueueSize: 1000
+                      isFlushing: false
+                      hasScheduledFlush: false
                     queues:
                       notifications-email:
                         name: notifications-email

--- a/docs/planning/security-hardening.md
+++ b/docs/planning/security-hardening.md
@@ -86,7 +86,7 @@ model AuditLog {
 ## Implementation Roadmap
 1. **Phase A (done)**: Document blueprint, introduce selective rate-limits for shift assignment & clock flows, update env examples + tests.
 2. **Phase B (done 2025-09-18)**: Prisma-Modell + Migration, Logging-Service mit Retry-Queue (`logAuditEvent`, `flushAuditLogQueue`) samt Tests/Doku.
-3. **Phase C (done 2025-09-19)**: Audit-Events für Auth/Shifts/Notifications integriert, Admin-Read-API (`GET /api/audit-logs`) inkl. Filter/Paging und Tests bereitgestellt.
+3. **Phase C (done 2025-09-19)**: Audit-Events für Auth/Users/Shifts/Incidents/Notifications integriert (inkl. Test-Sendungen & Fehlpfade), Admin-Read-API (`GET /api/audit-logs`) inkl. Filter/Paging und Tests bereitgestellt.
 4. **Phase D (done 2025-09-19)**: CSV-Export bereitgestellt, `/api/stats` um Audit-Kennzahlen ergänzt, Queue-Konfiguration dokumentiert.
 5. **Phase E (done 2025-09-19)**: Retention-Job (`npm run audit:prune`), Prometheus-Metriken und Export-Flow finalisiert; nächste Schritte: Dashboards & Alerts konfigurieren.
 


### PR DESCRIPTION
## Summary
- harden the audit log service for prisma-less tests and expose the runtime queue state via getAuditLogState
- introduce a shared audit helper (build/submit) and migrate controllers to structured audit events covering auth, users, shifts, incidents, and notifications
- surface the audit queue in /api/stats, refresh unit tests, and update docs/openapi/agent guidance for the expanded audit coverage

## Testing
- not run (not yet configured)

------
https://chatgpt.com/codex/tasks/task_e_68caf8807e3c8329aaa5487c32159479