### PR TITLE
fix: scope audit helpers to service groundwork

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -32,7 +32,7 @@ Du bist Senior-Full-Stack-Entwickler (Node.js, TypeScript, Express, Prisma, Post
 ## Roadmap (Priorität – kurz)
 1) ✅ **Observability** – `/api/stats` um Laufzeit-/Queue-/Success-Rate erweitert & README Logging-Runbook (2025-09-15).
 2) ✅ **Notifications** – Templates, Echtzeit-Events & Opt-In/Out vorbereitet (Feature-Flags, Tests, Docs) (2025-09-16).
-3) ✅ **Security-Hardening** – Phase E (Retention-Job `npm run audit:prune`, Prometheus-Metriken, `/api/stats` Audit-Kennzahlen) abgeschlossen 2025-09-19; Phase D (Audit-CSV-Export) 2025-09-19; Phase C (Audit-Events + Read-API) 2025-09-19; Phase B (Prisma-AuditLog + Queue) 2025-09-18; Phase A (Blueprint & Limits) 2025-09-17. Nächste Schritte: Dashboards & Alerting feintunen.
+3) ✅ **Security-Hardening** – Phase E (Retention-Job `npm run audit:prune`, Prometheus-Metriken, `/api/stats` Audit-Kennzahlen) abgeschlossen 2025-09-19; Phase D (Audit-CSV-Export) 2025-09-19; Phase C (Audit-Events + Read-API) 2025-09-19; Phase B (Prisma-AuditLog + Queue) 2025-09-18; Phase A (Blueprint & Limits) 2025-09-17. Audit-Helfer `buildAuditEvent`/`submitAuditEvent` bündeln Actor-Metadaten für Controller. Nächste Schritte: Dashboards & Alerting feintunen.
 4) ⏭️ **Telemetry/Dashboards** – Prometheus/Grafana Panels versionieren, PromQL-Snippets dokumentieren.
 5) ⏭️ **Ops/Compose** – Healthchecks & Migrationslauf in Docker-Stacks finalisieren (`docker-compose*.yml`, `.env.example`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- security: Audit-Log-Service toleriert fehlende Prisma-Modelle (Tests/Mocks), bietet `getAuditLogState()` für Laufzeitsnapshots und liefert mit `buildAuditEvent`/`submitAuditEvent` konsistente Audit-Metadaten.
 - docs: Security-Hardening Blueprint (`docs/planning/security-hardening.md`) mit Rate-Limit- und Audit-Trail-Konzept.
 - backend/shifts: Selektive Rate-Limits für Schicht-Zuweisung (`SHIFT_ASSIGN_RATE_LIMIT_*`) sowie Clock-in/out (`SHIFT_CLOCK_RATE_LIMIT_*`) inkl. Tests & ENV-Beispielen.
 - security: Prisma `AuditLog` Modell + Migration, Logging-Service (`logAuditEvent`/`flushAuditLogQueue`) mit Retry-Queue, Tests & Doku (Phase B).

--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Beispiele
 
 ## Audit-Trail (Phase E)
 - Prisma-Modell `AuditLog` persistiert sicherheitsrelevante Aktionen (Actor, Ressource, Outcome, optional Payload) in der Tabelle `audit_logs`.
-- Service `logAuditEvent` schreibt synchron; bei Fehlern landen Events in einer In-Memory-Retry-Queue (`flushAuditLogQueue` leert sie batchweise, Default alle 2 s / max. 25 Events) und Prometheus-Metriken zählen direkte/Flush-Erfolge bzw. -Fehler (`audit_log_events_total`, `audit_log_failures_total`, `audit_log_queue_size`).
+- Service `logAuditEvent` schreibt synchron; bei Fehlern landen Events in einer In-Memory-Retry-Queue (`flushAuditLogQueue` leert sie batchweise, Default alle 2 s / max. 25 Events) und Prometheus-Metriken zählen direkte/Flush-Erfolge bzw. -Fehler (`audit_log_events_total`, `audit_log_failures_total`, `audit_log_queue_size`). Fällt das Prisma-Modell `auditLog` (z. B. in Tests) weg, werden Events verlustfrei verworfen und genau einmal gewarnt statt Exceptions zu werfen.
+- `getAuditLogState()` liefert einen Laufzeitsnapshot (Queue-Größe, Flush-Status, Konfiguration) für `/api/stats` bzw. spätere Observability-Auswertungen.
+- Hilfsfunktionen in `utils/audit.ts` sammeln Actor-, Request- und Client-Metadaten (`buildAuditEvent`, `submitAuditEvent`), `recordAuditEvent` nutzt sie für Controller-Aufrufe.
 - Queue ist per ENV einstellbar (`AUDIT_LOG_FLUSH_INTERVAL_MS`, `AUDIT_LOG_BATCH_SIZE`, `AUDIT_LOG_MAX_QUEUE`, `AUDIT_RETENTION_DAYS`); bei voller Queue werden älteste Einträge verworfen (Warn-Log).
 - Events werden für Auth (Login/Refresh), Schichten (Create/Update/Delete, Assign, Clock in/out) und Notification-Opt-Ins/-Outs aufgezeichnet – inkl. Fehlpfaden (z. B. nicht zugewiesen, ungültiger Token).
 - Admins rufen das Journal via `GET /api/audit-logs` (RBAC `ADMIN`) mit Paging & Filtern (`actorId`, `resourceType`, `resourceId`, `action`, `outcome`, `from`, `to`) ab – CSV-Export via `GET /api/audit-logs/export?format=csv` (gleiche Filter).

--- a/backend/src/utils/audit.ts
+++ b/backend/src/utils/audit.ts
@@ -1,0 +1,87 @@
+import type { Request } from 'express';
+import { logAuditEvent, type AuditLogEventInput } from '../services/auditLogService';
+import logger from './logger';
+
+export type RequestActor = { id?: string | null; role?: string | null } | undefined;
+
+type BuildableAuditEvent = Omit<AuditLogEventInput, 'actorId' | 'actorRole' | 'actorIp' | 'requestId' | 'userAgent'> &
+  Partial<Pick<AuditLogEventInput, 'actorId' | 'actorRole' | 'actorIp' | 'requestId' | 'userAgent'>>;
+
+function normalizeUserAgent(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function getRequestUser(req: Request): RequestActor {
+  return (req.user as RequestActor) || undefined;
+}
+
+export function extractClientIp(req: Request): string | null {
+  const headerCandidates: Array<string | string[] | undefined> = [
+    req.headers['x-forwarded-for'],
+    req.headers['x-real-ip'],
+    req.headers['cf-connecting-ip'],
+  ];
+
+  for (const header of headerCandidates) {
+    if (!header) {
+      continue;
+    }
+    if (Array.isArray(header)) {
+      const value = header.find((entry) => entry && entry.trim().length > 0);
+      if (value) {
+        return value.split(',')[0]?.trim() || null;
+      }
+      continue;
+    }
+    if (typeof header === 'string' && header.trim().length > 0) {
+      return header.split(',')[0]?.trim() || null;
+    }
+  }
+
+  if (typeof req.ip === 'string' && req.ip.length > 0) {
+    return req.ip;
+  }
+
+  const socketIp = req.socket?.remoteAddress;
+  return typeof socketIp === 'string' && socketIp.length > 0 ? socketIp : null;
+}
+
+function resolveRequestId(req: Request): string | null {
+  if (typeof (req as any).id === 'string' && (req as any).id.length > 0) {
+    return (req as any).id;
+  }
+  const headerId = req.headers['x-request-id'];
+  if (typeof headerId === 'string' && headerId.length > 0) {
+    return headerId;
+  }
+  return null;
+}
+
+export function buildAuditEvent(req: Request, event: BuildableAuditEvent): AuditLogEventInput {
+  const actor = getRequestUser(req);
+  return {
+    action: event.action,
+    resourceType: event.resourceType,
+    resourceId: event.resourceId ?? null,
+    actorId: event.actorId ?? actor?.id ?? null,
+    actorRole: event.actorRole ?? actor?.role ?? null,
+    actorIp: event.actorIp ?? extractClientIp(req),
+    requestId: event.requestId ?? resolveRequestId(req),
+    userAgent: event.userAgent ?? normalizeUserAgent(req.headers['user-agent']),
+    outcome: event.outcome ?? null,
+    data: event.data ?? null,
+    occurredAt: event.occurredAt ?? new Date(),
+  };
+}
+
+export async function submitAuditEvent(req: Request, event: BuildableAuditEvent): Promise<void> {
+  try {
+    await logAuditEvent(buildAuditEvent(req, event));
+  } catch (error) {
+    logger.warn('Failed to submit audit event: %o', error);
+  }
+}
+
+export function getAuditActorIp(req: Request): string | null {
+  return extractClientIp(req);
+}

--- a/backend/src/utils/auditTrail.ts
+++ b/backend/src/utils/auditTrail.ts
@@ -1,68 +1,29 @@
 import type { Request } from 'express';
-import logger from './logger';
-import { logAuditEvent, type AuditLogEventInput } from '../services/auditLogService';
+import { type AuditLogEventInput } from '../services/auditLogService';
+import { extractClientIp, submitAuditEvent } from './audit';
 
 export type AuditEventDetails = Pick<AuditLogEventInput, 'action' | 'resourceType' | 'resourceId' | 'outcome' | 'data' | 'occurredAt'>;
 
 export type AuditActorOverrides = Pick<AuditLogEventInput, 'actorId' | 'actorRole' | 'actorIp' | 'userAgent' | 'requestId'>;
-
-function extractClientIp(req: Request): string | null {
-  const headerCandidates: Array<string | string[] | undefined> = [
-    req.headers['x-forwarded-for'],
-    req.headers['x-real-ip'],
-    req.headers['cf-connecting-ip'],
-  ];
-
-  for (const header of headerCandidates) {
-    if (!header) {
-      continue;
-    }
-    if (Array.isArray(header)) {
-      const value = header.find((entry) => entry && entry.trim().length > 0);
-      if (value) {
-        return value.split(',')[0]?.trim() || null;
-      }
-      continue;
-    }
-    if (typeof header === 'string' && header.trim().length > 0) {
-      return header.split(',')[0]?.trim() || null;
-    }
-  }
-
-  if (typeof req.ip === 'string' && req.ip.length > 0) {
-    return req.ip;
-  }
-
-  const socketIp = req.socket?.remoteAddress;
-  return typeof socketIp === 'string' && socketIp.length > 0 ? socketIp : null;
-}
 
 export async function recordAuditEvent(
   req: Request,
   details: AuditEventDetails,
   overrides: AuditActorOverrides = {},
 ): Promise<void> {
-  const event: AuditLogEventInput = {
+  await submitAuditEvent(req, {
     action: details.action,
     resourceType: details.resourceType,
     resourceId: details.resourceId ?? null,
     outcome: details.outcome ?? null,
     data: details.data ?? null,
     occurredAt: details.occurredAt ?? new Date(),
-    actorId: overrides.actorId ?? req.user?.id ?? null,
-    actorRole: overrides.actorRole ?? req.user?.role ?? null,
-    actorIp: overrides.actorIp ?? extractClientIp(req),
-    requestId: overrides.requestId ?? req.id ?? (typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : null),
-    userAgent:
-      overrides.userAgent ??
-      (typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : null),
-  };
-
-  try {
-    await logAuditEvent(event);
-  } catch (error) {
-    logger.warn('Failed to record audit event: %o', error);
-  }
+    actorId: overrides.actorId,
+    actorRole: overrides.actorRole,
+    actorIp: overrides.actorIp,
+    userAgent: overrides.userAgent,
+    requestId: overrides.requestId,
+  });
 }
 
 export function getAuditActorIp(req: Request): string | null {


### PR DESCRIPTION
## Summary
- limit audit instrumentation to the shared recordAuditEvent helper while reverting controllers and tests away from direct submitAuditEvent usage
- document the audit-log service guard, queue state accessor, and shared audit metadata builder across README, changelog, and agent guidance
- roll back the /api/stats OpenAPI shape and planning notes to match the reduced audit output

## Testing
- not run (per project instructions)

------
https://chatgpt.com/codex/tasks/task_e_68caf8807e3c8329aaa5487c32159479