### PR TITLE
fix(security): remove public port mapping for postgres (Fixes #26)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,8 +7,8 @@ services:
       POSTGRES_DB: sicherheitsdienst_db
     volumes:
       - db_data:/var/lib/postgresql/data
-    ports:
-      - '5432:5432'
+    # ports:
+    #   - '5432:5432'
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d sicherheitsdienst_db"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-admin}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin123}
     # SECURITY: Port für lokale Entwicklung exponiert
-    ports:
-      - '5432:5432'
+    # ports:
+    #   - '5432:5432'
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
Address Issue #26: Make PostgreSQL not publicly accessible.

- Removed external port mapping (5432:5432) from  and .
- Verified that the database is not accessible from the host ( is empty).
- Verified that the API can still connect to the database ( returns ok).

Closes #26