### PR TITLE
feat(security): enforce strong secrets and validation (Fixes #27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ PUBLIC_HOST=localhost
 
 # Traefik / HTTPS
 DOMAIN=localhost
-ACME_EMAIL=admin@example.com
+ACME_EMAIL=
 
 # Monitoring (docker-compose.monitoring.yml)
 # Provide at least the Slack webhook; channels are optional and default to sensible values.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response, ErrorRequestHandler } from 'express'; // ErrorRequestHandler importiert
 import morgan from 'morgan';
-import dotenv from 'dotenv';
+// dotenv.config() removed, handled in config/env.ts
 import jwt from 'jsonwebtoken';
 import swaggerUi from 'swagger-ui-express';
 import logger from './utils/logger';
@@ -9,9 +9,7 @@ import { onRequestStart, onResponseStatus } from './utils/stats';
 import { applySecurity } from './middleware/security';
 import { httpRequestDurationSeconds, httpRequestsTotal } from './utils/metrics';
 import { setCustomerContext } from './middleware/multiTenancy'; // 🔐 Multi-Tenancy
-
-// Load environment variables
-dotenv.config();
+import { config } from './config/env';
 
 // Import all routes
 import {
@@ -87,7 +85,7 @@ app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 app.use(setCustomerContext);
 
 // Swagger UI (nur Development): zeigt docs/openapi.yaml unter /api-docs
-if (process.env.NODE_ENV !== 'production') {
+if (config.NODE_ENV !== 'production') {
   // Statische Auslieferung der Spezifikation
   app.use('/api-docs-spec', express.static('docs'));
   // Swagger UI mit Verweis auf die YAML-Spezifikation
@@ -102,7 +100,7 @@ app.get('/', (req: Request, res: Response) => {
     message: '🛡️ Sicherheitsdienst-Tool Backend API',
     version: process.env.npm_package_version || '1.0.0',
     status: 'Running',
-    documentation: process.env.NODE_ENV !== 'production' ? '/api-docs' : undefined,
+    documentation: config.NODE_ENV !== 'production' ? '/api-docs' : undefined,
     endpoints: {
       health: '/health',
       healthz: '/healthz',
@@ -230,7 +228,7 @@ const globalErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
     errorResponse.errors = errorsArray;
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (config.NODE_ENV === 'development') {
     errorResponse.details = err.message;
     errorResponse.stack = err.stack;
     if (!code && err.code) errorResponse.code = String(err.code);

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import dotenv from 'dotenv';
+import logger from '../utils/logger';
+
+// Load .env file (if exists)
+dotenv.config();
+
+const envSchema = z.object({
+  // Server
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  PORT: z.string().transform(Number).default('3000'),
+  LOG_LEVEL: z.enum(['error', 'warn', 'info', 'http', 'debug']).default('info'),
+  LOG_FORMAT: z.enum(['json', 'simple']).default('simple'),
+
+  // Database
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+
+  // Auth & Secrets
+  JWT_SECRET: z.string()
+    .min(32, 'JWT_SECRET must be at least 32 characters long')
+    .refine((val) => !['change-me', 'changeme', 'secret', 'default'].includes(val), {
+      message: 'JWT_SECRET must not be a default insecure value',
+    }),
+  REFRESH_SECRET: z.string()
+    .min(32, 'REFRESH_SECRET must be at least 32 characters long')
+    .refine((val) => !['change-me-refresh', 'changeme', 'secret'].includes(val), {
+      message: 'REFRESH_SECRET must not be a default insecure value',
+    }),
+  JWT_EXPIRES_IN: z.string().default('7d'),
+  REFRESH_EXPIRES_IN: z.string().default('30d'),
+
+  // CORS
+  CORS_ORIGIN: z.string().optional(),
+  CORS_ORIGINS: z.string().optional(),
+});
+
+// Parse and validate environment variables
+const parseEnv = () => {
+  const result = envSchema.safeParse(process.env);
+
+  if (!result.success) {
+    console.error('❌ Invalid environment variables:', JSON.stringify(result.error.format(), null, 2));
+    // In production, we crash immediately if secrets are unsafe
+    if (process.env.NODE_ENV === 'production') {
+       console.error('🚨 Critical configuration error. Exiting...');
+       process.exit(1);
+    }
+    // In dev, we might just warn, but the issue says "App startet nicht ohne gesetzte Secrets"
+    // So we should strictly enforce it everywhere.
+    throw new Error('Invalid environment variables');
+  }
+
+  return result.data;
+};
+
+// Export the validated config
+export const config = parseEnv();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,8 +3,9 @@ import logger from './utils/logger';
 import prisma from './utils/prisma';
 import { startIntelligentReplacementSchedulers } from './jobs/intelligentReplacementJobs';
 import { registerMultiTenancyMiddleware } from './middleware/multiTenancy';
+import { config } from './config/env';
 
-const PORT = parseInt(process.env.PORT || '3000', 10); // Default: 3000 (konsistent mit Docker)
+const PORT = config.PORT;
 
 // 🔐 MULTI-TENANCY: Registriere Prisma-Middleware (KRITISCH!)
 registerMultiTenancyMiddleware();
@@ -16,7 +17,7 @@ const server = app.listen(PORT, '0.0.0.0', () => {
   logger.info('🛡️  Sicherheitsdienst-Tool Backend');
   logger.info('🚀 ================================');
   logger.info(`📡 Server running on port ${PORT} (listening on all interfaces)`);
-  logger.info(`🌍 Environment: ${process.env.NODE_ENV || 'development'}`);
+  logger.info(`🌍 Environment: ${config.NODE_ENV}`);
   logger.info('');
   logger.info('📍 Available Endpoints:');
   logger.info(`   ├─ Welcome:        http://localhost:${PORT}/`);

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,8 +23,8 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3000
-      JWT_SECRET: dev-secret
-      REFRESH_SECRET: dev-refresh
+      JWT_SECRET: dev-secret-minimum-32-chars-long-value
+      REFRESH_SECRET: dev-refresh-secret-minimum-32-chars-long
       CORS_ORIGIN: http://${PUBLIC_HOST:-localhost}:5173
       CORS_ORIGINS: http://localhost:5173,http://127.0.0.1:5173,http://37.114.53.56:5173
       RATE_LIMIT_MAX: 100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-sicherheitsdienst_db}
       POSTGRES_USER: ${POSTGRES_USER:-admin}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin123}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
     # SECURITY: Port für lokale Entwicklung exponiert
     # ports:
     #   - '5432:5432'
@@ -35,10 +35,10 @@ services:
       NODE_ENV: production
       PORT: 3001
       # Adjust to your DB credentials or override via environment
-      DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-admin}:${POSTGRES_PASSWORD:-admin123}@db:5432/${POSTGRES_DB:-sicherheitsdienst_db}?schema=public}
-      JWT_SECRET: ${JWT_SECRET:-changeme-in-env}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-admin}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}@db:5432/${POSTGRES_DB:-sicherheitsdienst_db}?schema=public}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET required}
       # Optional Refresh/SMTP envs are passed if defined host-side
-      REFRESH_SECRET: ${REFRESH_SECRET:-}
+      REFRESH_SECRET: ${REFRESH_SECRET:?REFRESH_SECRET required}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-}
       REFRESH_EXPIRES_IN: ${REFRESH_EXPIRES_IN:-}
       SMTP_HOST: ${SMTP_HOST:-}
@@ -106,7 +106,7 @@ services:
       # Let's Encrypt / ACME
       - "--certificatesresolvers.myresolver.acme.httpchallenge=true"
       - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
-      - "--certificatesresolvers.myresolver.acme.email=${ACME_EMAIL:-admin@example.com}"
+      - "--certificatesresolvers.myresolver.acme.email=${ACME_EMAIL:?ACME_EMAIL required}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:
       - "80:80"
@@ -135,7 +135,7 @@ services:
     restart: always
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@admin.com}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin123}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:?PGADMIN_DEFAULT_PASSWORD required}
     # SECURITY: Port nicht öffentlich exponieren - nur intern im Docker-Netzwerk
     # Zugriff via: docker exec -it sicherheitsdienst-db psql -U admin -d sicherheitsdienst_db
     # ports:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,37 @@
+# Konfiguration & Umgebungsvariablen
+
+Diese Anwendung benötigt zwingend das Setzen von Umgebungsvariablen für sicherheitskritische Werte. Es gibt keine unsicheren Fallback-Werte im Produktionsmodus.
+
+## Erforderliche Variablen (Produktion)
+
+Folgende Variablen MÜSSEN in der `.env` Datei oder in der Deployment-Umgebung gesetzt sein:
+
+### Sicherheit & Authentifizierung
+- `JWT_SECRET`: Secret für Access-Tokens (min. 32 Zeichen)
+- `REFRESH_SECRET`: Secret für Refresh-Tokens (min. 32 Zeichen)
+- `JWT_EXPIRES_IN`: Gültigkeitsdauer Access-Token (z.B. `7d`)
+- `REFRESH_EXPIRES_IN`: Gültigkeitsdauer Refresh-Token (z.B. `30d`)
+
+### Datenbank
+- `DATABASE_URL`: Vollständiger Connection-String (z.B. `postgresql://user:pass@db:5432/db?schema=public`)
+- `POSTGRES_USER`: DB-Benutzer
+- `POSTGRES_PASSWORD`: DB-Passwort
+- `POSTGRES_DB`: DB-Name
+
+### Infrastruktur & HTTPS
+- `DOMAIN`: Domain-Name für Traefik Routing (z.B. `example.com`)
+- `ACME_EMAIL`: E-Mail für Let's Encrypt Zertifikate
+
+### Monitoring & Verwaltung
+- `PGADMIN_DEFAULT_EMAIL`: Login für pgAdmin
+- `PGADMIN_DEFAULT_PASSWORD`: Passwort für pgAdmin
+
+## Entwicklung
+
+Für die lokale Entwicklung (`docker-compose.dev.yml`) sind Standardwerte vorkonfiguriert, die jedoch **NICHT** für den produktiven Einsatz verwendet werden dürfen.
+
+## Start-Verhalten
+
+Die Anwendung prüft beim Start (`backend/src/config/env.ts`), ob alle Variablen korrekt gesetzt sind.
+- **Fehlende Variablen:** Der Start wird abgebrochen (Exit Code 1).
+- **Zu kurze Secrets:** Der Start wird abgebrochen, wenn Secrets < 32 Zeichen sind oder Standardwerte wie `changeme` enthalten.


### PR DESCRIPTION
Address Issue #27: Default Credentials & Secret-Fallbacks entfernen.

- **Strict Validation:** Added `backend/src/config/env.ts` using Zod to validate environment variables at startup.
- **Strong Secrets:** `JWT_SECRET` and `REFRESH_SECRET` must now be at least 32 characters long and cannot be default values like 'changeme'.
- **No Defaults in Prod:** Removed insecure default values from `docker-compose.yml`. Missing variables will now cause the container to fail startup immediately (Fail-Fast).
- **Documentation:** Added `docs/CONFIGURATION.md` listing all required variables.

Closes #27