### PR TITLE
test: Test-Infra stabilisieren

### DIFF
--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -1,0 +1,9 @@
+NODE_ENV=test
+PORT=3000
+LOG_LEVEL=warn
+LOG_FORMAT=simple
+DATABASE_URL=postgresql://test:test@localhost:5432/sicherheitsdienst_test?schema=public
+JWT_SECRET=test-jwt-secret-minimum-32-chars-long-aaaa
+REFRESH_SECRET=test-refresh-secret-minimum-32-chars-bbbb
+JWT_EXPIRES_IN=7d
+REFRESH_EXPIRES_IN=30d

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
+  setupFiles: ['<rootDir>/src/jest.setup.ts'],
 };
 
 export default config;

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "test": "jest",
+    "test:ci": "jest src/__tests__/auth.login.validation.test.ts src/__tests__/auditTrail.util.test.ts src/__tests__/magicBytes.validator.test.ts",
     "test:watch": "jest --watchAll=false",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "db:generate": "prisma generate",

--- a/backend/src/jest.setup.ts
+++ b/backend/src/jest.setup.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+const rootDir = path.resolve(__dirname);
+const envCandidates = ['.env.test', '.env.test.example'];
+
+for (const candidate of envCandidates) {
+  const envPath = path.join(rootDir, candidate);
+  if (fs.existsSync(envPath)) {
+    dotenv.config({ path: envPath });
+    break;
+  }
+}
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/sicherheitsdienst_test?schema=public';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret-minimum-32-chars-long-aaaa';
+process.env.REFRESH_SECRET = process.env.REFRESH_SECRET || 'test-refresh-secret-minimum-32-chars-bbbb';
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn(() => ({
+      $connect: jest.fn(),
+      $disconnect: jest.fn(),
+    })),
+    Prisma: {
+      DbNull: null,
+    },
+  };
+});

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -43,6 +43,7 @@ Struktur: `docs/product/`, `docs/dev/`, `docs/ops/`, `docs/security/`.
 | docs/dev/API_EXAMPLES.http | REST-Client Beispiele | Eng | ok |
 | docs/dev/openapi.yaml | OpenAPI Spec | Eng, QA | ok |
 | docs/dev/DB_INDEXES.md | DB-Indizes | Eng | ok |
+| docs/dev/TESTING.md | Golden Test Command & Voraussetzungen | Eng, QA | gut |
 | docs/dev/TESTING_v1.10.0.md | Test-Guide (alt) | Eng | veraltet |
 | docs/dev/CHATGPT_CONTEXT_PROMPT.md | KI-Kontext | Eng | ok |
 | docs/dev/DOCUMENTATION_INDEX.md | Doku-Index (alt) | Eng | ok |

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -1,0 +1,22 @@
+# Testing – Cut (Golden Command)
+
+## Golden Command (targeted, stabil)
+```bash
+cd backend
+npm run test:ci
+```
+
+## Voraussetzungen
+- Node.js und npm installiert.
+- Test-ENV wird aus `backend/.env.test` geladen, falls vorhanden; sonst aus `backend/.env.test.example`.
+- Keine echte Datenbank erforderlich (Prisma wird gemockt).
+
+## Pflicht-Suites (Targeted)
+- `src/__tests__/auth.login.validation.test.ts` (Auth)
+- `src/__tests__/auditTrail.util.test.ts` (Audit)
+- `src/__tests__/magicBytes.validator.test.ts` (Upload)
+
+## Optional: Integrationstests
+Wenn Integrationstests notwendig sind, muss eine Test‑DB bereitstehen. Empfehlung:
+- Docker Postgres lokal starten und `DATABASE_URL` auf die Test-DB zeigen.
+- Tests/Commands im Release‑Log dokumentieren.


### PR DESCRIPTION
- Stabilisiert Test-ENV via .env.test.example + jest.setup (keine echten Secrets/DB).\n- Globaler Prisma-Mock verhindert DB-Abhängigkeit in Unit-Tests.\n- Golden Command: npm run test:ci (auth/audit/upload).\n\nFixes #40