### PR TITLE
ops: Smoke-Test Script

### DIFF
--- a/docs/ops/GO_NO_GO.md
+++ b/docs/ops/GO_NO_GO.md
@@ -6,6 +6,7 @@
 - **Ports:** 80/443 offen für Traefik, DB nicht öffentlich.
 - **Compose-Stacks:** Prod `docker-compose.yml` ohne Mailhog; Dev optional mit Mailhog.
 - **HTTPS:** Zertifikat gültig oder Open Point dokumentiert.
+- **Smoke-Test:** `scripts/smoke.sh` (Health/Ready/Auth).
 
 ## Backup/Restore Minimum
 - Backup-Skript: `docs/ops/backup.sh` ausgeführt.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+
+check_status() {
+  local name="$1"
+  local url="$2"
+  local expected="$3"
+  local code
+  code="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
+  if [[ "$code" != "$expected" ]]; then
+    echo "FAIL: $name ($url) expected $expected, got $code"
+    exit 1
+  fi
+  echo "OK: $name ($code)"
+}
+
+check_status "health" "$BASE_URL/health" "200"
+check_status "readyz" "$BASE_URL/readyz" "200"
+check_status "unauth-protected" "$BASE_URL/api/users" "401"
+
+echo "Smoke test passed."


### PR DESCRIPTION
- Fügt scripts/smoke.sh für Health/Ready/Auth-Prüfungen hinzu.\n- Verlinkt Smoke-Test im Go/No-Go Runbook.\n\nFixes #42