### PR TITLE
chore: Repo-Hygiene .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ web_modules/
 
 # dotenv environment variable files
 .env
+.env.test
 .env.development.local
 .env.test.local
 .env.production.local
@@ -142,23 +143,11 @@ dist
 # Document storage (runtime)
 storage/
 
+# Uploads (runtime)
+backend/uploads/
+
 # Local backup artifacts
 .backups/
 
 # LetsEncrypt ACME storage
 letsencrypt/
-
-# Docker build cache
-[base
-[build
-[deps
-[internal]
-[runner
-exporting
-naming
-reading
-resolving
-transferring
-writing
-CACHED
-=


### PR DESCRIPTION
- Bereinigt .gitignore (entfernt Docker-Build-Noise, ergänzt .env.test und runtime uploads).\n\nFixes #46\n\nRisikoanalyse:\n- Risiko: Ignorieren von runtime Uploads/ENV-Testdateien kann lokale Debug-Artefakte verbergen.\n- Mitigation: Keine Runtime- oder Build-Änderungen; Änderungen betreffen nur Git-Ignore.\n\nNachweis (lokal):\n- Backend: `cd backend && npm run test:ci` → PASS\n- Frontend: `cd frontend && npm run build` → PASS\n- Smoke: `BASE_URL=http://localhost:3001 scripts/smoke.sh` → exit=0\n