### PR TITLE
refactor: konsolidiere Shift DTOs

### DIFF
--- a/frontend/src/features/shifts/api.ts
+++ b/frontend/src/features/shifts/api.ts
@@ -1,23 +1,12 @@
 import { api } from '@/lib/api';
+import type { ShiftBase, ShiftStatus } from '@/types/shift';
 
 // ============================================================================
 // Shift Types
 // ============================================================================
 
-export interface Shift {
-  id: string;
-  siteId: string;
-  title: string;
-  description?: string;
-  location?: string;
-  startTime: string;
-  endTime: string;
-  requiredEmployees: number;
-  assignedEmployees?: number;
-  requiredQualifications: string[];
-  status: 'PLANNED' | 'CONFIRMED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
-  createdAt?: string;
-  updatedAt?: string;
+export interface Shift extends ShiftBase {
+  status: ShiftStatus;
   assignments?: ShiftAssignment[];
   site?: {
     id: string;

--- a/frontend/src/features/sites/api.ts
+++ b/frontend/src/features/sites/api.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
+import type { ShiftBase } from '@/types/shift';
 import { toast } from '@/lib/utils';
 import { WizardData } from '../../types/wizard';
 
@@ -299,21 +300,7 @@ export async function fetchAssignmentCandidates(siteId: string, role?: string) {
 // Shift API Functions
 // ============================================================================
 
-export interface Shift {
-  id: string;
-  siteId: string;
-  title: string;
-  description?: string;
-  location?: string;
-  startTime: string;
-  endTime: string;
-  requiredEmployees: number;
-  assignedEmployees?: number;
-  requiredQualifications: string[];
-  status: 'PLANNED' | 'CONFIRMED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
-  createdAt?: string;
-  updatedAt?: string;
-}
+export type Shift = ShiftBase;
 
 export interface GenerateShiftsPayload {
   startDate: string; // ISO 8601

--- a/frontend/src/types/shift.ts
+++ b/frontend/src/types/shift.ts
@@ -1,0 +1,17 @@
+export type ShiftStatus = 'PLANNED' | 'CONFIRMED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+
+export interface ShiftBase {
+  id: string;
+  siteId: string;
+  title: string;
+  description?: string;
+  location?: string;
+  startTime: string;
+  endTime: string;
+  requiredEmployees: number;
+  assignedEmployees?: number;
+  requiredQualifications: string[];
+  status: ShiftStatus;
+  createdAt?: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
- Führt gemeinsames Shift-Basismodell in frontend/src/types/shift.ts ein.\n- Vereinheitlicht Shift-DTOs in shifts/api.ts und sites/api.ts.\n\nFixes #49\n\nRisikoanalyse:\n- Risiko: Typ-Import/Export könnte zu inkonsistenten DTO-Feldern führen.\n- Mitigation: Nur gemeinsame Basisfelder extrahiert; API-spezifische Felder bleiben lokal.\n\nNachweis (lokal):\n- Backend: `cd backend && npm run test:ci` → PASS\n- Frontend: `cd frontend && npm run build` → PASS\n- Smoke: `BASE_URL=http://localhost:3001 scripts/smoke.sh` → exit=0\n