### PR TITLE
fix: Externalize Grafana credentials + harden port bindings

### DIFF
--- a/docs/ops/monitoring-compose.yml
+++ b/docs/ops/monitoring-compose.yml
@@ -3,7 +3,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prom
-    ports: ["9090:9090"]
+    ports: ["127.0.0.1:9090:9090"]
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus-alerts.yaml:/etc/prometheus/alerts.yaml:ro
@@ -14,7 +14,7 @@ services:
   alertmanager:
     image: prom/alertmanager:latest
     container_name: alertmanager
-    ports: ["9093:9093"]
+    ports: ["127.0.0.1:9093:9093"]
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     networks: [mon]
@@ -22,10 +22,10 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
-    ports: ["3002:3000"]
+    ports: ["127.0.0.1:3002:3000"]
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:?required}
     networks: [mon]
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
@@ -35,7 +35,7 @@ services:
   blackbox:
     image: prom/blackbox-exporter:latest
     container_name: blackbox
-    ports: ["9115:9115"]
+    ports: ["127.0.0.1:9115:9115"]
     networks: [mon]
 
 networks:

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -5,7 +5,7 @@ services:
     image: prom/alertmanager:latest
     container_name: sicherheitsdienst-alertmanager
     ports:
-      - '9093:9093'
+      - '127.0.0.1:9093:9093'
     environment:
       ALERTMANAGER_SLACK_WEBHOOK: ${ALERTMANAGER_SLACK_WEBHOOK}
       ALERTMANAGER_SLACK_CHANNEL: ${ALERTMANAGER_SLACK_CHANNEL}
@@ -23,7 +23,7 @@ services:
     image: prom/prometheus:latest
     container_name: sicherheitsdienst-prometheus
     ports:
-      - '9090:9090'
+      - '127.0.0.1:9090:9090'
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./alerts/alerts.yml:/etc/prometheus/alerts.yml:ro
@@ -41,10 +41,10 @@ services:
     image: grafana/grafana:latest
     container_name: sicherheitsdienst-grafana
     ports:
-      - '3300:3000'
+      - '127.0.0.1:3300:3000'
     environment:
       GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:?required}
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
@@ -58,7 +58,7 @@ services:
     image: prom/blackbox-exporter:latest
     container_name: sicherheitsdienst-blackbox
     ports:
-      - '9115:9115'
+      - '127.0.0.1:9115:9115'
     command:
       - '--config.file=/etc/blackbox_exporter/config.yml'
     volumes:


### PR DESCRIPTION
## Summary
- Replace hardcoded `GF_SECURITY_ADMIN_PASSWORD: admin` with `${GF_ADMIN_PASSWORD:?required}` in monitoring compose files
- Harden all monitoring service port bindings from `0.0.0.0` to `127.0.0.1` (Prometheus, Alertmanager, Grafana, Blackbox)
- Affects both `monitoring/docker-compose.monitoring.yml` and `docs/ops/monitoring-compose.yml`

## Security
| Issue | Before | After |
|-------|--------|-------|
| Grafana password | `admin` (hardcoded) | `${GF_ADMIN_PASSWORD:?required}` |
| Port bindings | `0.0.0.0:9090`, etc. | `127.0.0.1:9090`, etc. |

## Test plan
- [ ] Set `GF_ADMIN_PASSWORD` in environment
- [ ] `docker compose -f monitoring/docker-compose.monitoring.yml config` → valid
- [ ] Verify ports bind to 127.0.0.1 only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>