### PR TITLE
fix(security): traefik image-tag auf v3 pinnen (#143)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,11 @@ services:
 
   # Traefik Reverse Proxy
   traefik:
-    image: traefik:latest
+    # Pinned auf v3 statt :latest damit ein Upstream-v4-Release nicht
+    # versehentlich eingespielt wird (config-breaking changes).
+    # Gleichzeitig holen wir v3-Patch-Updates (zuletzt v3.6.13 mit Fixes
+    # fuer CVE-2026-22184 zlib und CVE-2026-40200 musl).
+    image: traefik:v3
     container_name: sicherheitsdienst-traefik
     restart: always
     command:


### PR DESCRIPTION
## Security-Haertung: image-tag fuer traefik

### Was aendert sich

\`docker-compose.yml\` (traefik-service):
- Vorher: \`image: traefik:latest\`
- Nachher: \`image: traefik:v3\`

### Warum

1. **Kein unkontrollierter Major-Sprung**: \`:latest\` wuerde beim naechsten Pull eine potenzielle v4 ziehen und die Config-Syntax brechen. \`:v3\` haelt uns im kompatiblen Bereich.
2. **Patch-Updates kommen automatisch**: \`:v3\` floatet auf den neuesten v3.x.y. Aktueller laufender Container ist v3.6.12, der Tag zeigt aktuell auf v3.6.13.
3. **CVE-Fixes in v3.6.13 vs v3.6.12**:
   - \`CVE-2026-22184\` zlib buffer overflow (HIGH) — gefixt
   - \`CVE-2026-40200\` musl libc arbitrary code execution (HIGH) — gefixt

Nach Merge: \`docker compose pull traefik && docker compose up -d traefik\` zieht das neue Image und startet den Container neu (<10s Downtime).

### Was noch offen bleibt

\`traefik:v3.6.13\` enthaelt weiterhin:
- \`CVE-2026-32280\` (Go stdlib chain building DoS)
- \`CVE-2026-34040\` (Moby authorization bypass)
- \`CVE-2026-34986\` (go-jose)

Diese warten auf Upstream-Rebuilds der Base-Images. Kein Quick-Fix von unserer Seite moeglich — der Traefik-Maintainer muss neu bauen nachdem Go-stdlib 1.25.9 / 1.26.2 propagiert.

### Verifikation

\`\`\`bash
$ trivy image traefik:v3.6.12 | grep -c HIGH
8
$ trivy image traefik:v3 | grep -c HIGH
5
\`\`\`

Drei CVEs weniger, keine neue.

Refs #143.