### PR TITLE
fix: Traefik Container-Härtung (cap_drop ALL, no-new-privileges)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,6 +211,12 @@ services:
       - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
       - "--certificatesresolvers.myresolver.acme.email=${ACME_EMAIL:?ACME_EMAIL required}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- Finding #323: Traefik Container lief ohne Capability-Einschränkungen und ohne `no-new-privileges`
- `cap_drop: ALL` + `cap_add: NET_BIND_SERVICE` (einzige benötigte Capability für Port 80/443)
- `security_opt: no-new-privileges:true` verhindert Privilege Escalation

## Test plan
- [ ] `docker compose up -d traefik` — Container startet fehlerfrei
- [ ] HTTP→HTTPS Redirect funktioniert
- [ ] Let's Encrypt Zertifikate werden erneuert
- [ ] Alle hinter Traefik liegenden Services erreichbar (GuildScout, ZERODOX)
- [ ] `docker inspect sicherheitsdienst-traefik` zeigt CapDrop und SecurityOpt

## Hinweis
Nach Merge muss der Traefik-Container neu erstellt werden:
```bash
cd ~/project && docker compose up -d traefik
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)