### PR TITLE
fix(security): Traefik v3.6.17 → v3.6.19

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,10 +185,9 @@ services:
   traefik:
     # Pinned auf eine konkrete v3.6-Patch-Version damit weder v4 noch v3.7 (Minor)
     # versehentlich eingespielt werden (config-breaking changes).
-    # 2026-05-24: v3.6.14 → v3.6.17 (CVE-2026-44774 + Folgefixes,
-    # GHSA-96qj-4jj5-wcjc). Vorher: traefik:v3 (moving tag, zuletzt
-    # v3.6.13 mit CVE-2026-22184 zlib + CVE-2026-40200 musl).
-    image: traefik:v3.6.17
+    # 2026-07-18: v3.6.17 → v3.6.19 (Trivy-Reports bestätigen v3.6.19
+    # als aktuellen Runtime-Stand; CVE-2026-48020 + Folgefixes).
+    image: traefik:v3.6.19
     container_name: sicherheitsdienst-traefik
     restart: always
     command:


### PR DESCRIPTION
## Summary
- Traefik-Image-Tag von `v3.6.17` auf `v3.6.19` aktualisiert
- Schließt Deployment-Drift: Trivy-Reports und Runtime zeigen bereits v3.6.19, Compose pinnte v3.6.17
- Verhindert versehentliches Downgrade bei nächstem `docker compose up -d`

## Finding
- **ID:** #423 (MEDIUM) — Traefik-Compose pinnt veralteten Edge-Proxy
- **Issue:** https://github.com/Commandershadow9/shadowops-bot/issues/366

## Test plan
- [ ] `docker compose config` prüfen (kein Syntaxfehler)
- [ ] Nach Deploy: `docker inspect sicherheitsdienst-traefik --format '{{.Config.Image}}'` = `traefik:v3.6.19`
- [ ] Health-Check: `curl -s https://zerodox.de/api/health` und `curl -s https://guildscout.eu/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)